### PR TITLE
플레이어 정보 검색 기능 구현

### DIFF
--- a/src/main/java/com/dmk/coctown/common/config/RestTemplateConfig.java
+++ b/src/main/java/com/dmk/coctown/common/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.dmk.coctown.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/dmk/coctown/home/controller/HomeController.java
+++ b/src/main/java/com/dmk/coctown/home/controller/HomeController.java
@@ -1,0 +1,13 @@
+package com.dmk.coctown.home.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    @GetMapping("/")
+    public String home() {
+        return "index";
+    }
+}

--- a/src/main/java/com/dmk/coctown/player/controller/PlayerController.java
+++ b/src/main/java/com/dmk/coctown/player/controller/PlayerController.java
@@ -1,0 +1,26 @@
+package com.dmk.coctown.player.controller;
+
+import com.dmk.coctown.player.dto.Player;
+import com.dmk.coctown.player.service.PlayerService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@Slf4j
+@RequestMapping("/players")
+@RequiredArgsConstructor
+public class PlayerController {
+
+    private final PlayerService playerService;
+
+    @GetMapping("/{playerTag}")
+    @ResponseBody
+    public Player searchPlayer(@PathVariable String playerTag) {
+
+        log.debug("playerTag: {}", playerTag);
+        return playerService.searchPlayer(playerTag);
+    }
+}

--- a/src/main/java/com/dmk/coctown/player/dto/Player.java
+++ b/src/main/java/com/dmk/coctown/player/dto/Player.java
@@ -1,0 +1,27 @@
+package com.dmk.coctown.player.dto;
+
+import lombok.Getter;
+
+@Getter
+public class Player {
+
+    private String tag; // 태그
+    private String name; // 닉네임
+    private Integer townHallLevel; // 마을 회관 레벨
+    private Integer townHallWeaponLevel; // 마을 회관 무기 레벨
+    private Integer expLevel; // 플레이어 레벨
+    private Integer trophies; // 트로피 점수
+    private Integer bestTrophies; // 마을회관 최고 트로피 점수
+    private Integer warStars ; // 전쟁별 개수
+    private Integer builderHallLevel ; // 장인회관 레벨
+    private Integer builderBaseTrophies ; // 장인회관 트로피 점수
+    private Integer bestBuilderBaseTrophies ; // 장인회관 최고 트로피 점수
+    private String role; // 플레이어 역할 ENUM: [NOT_MEMBER, MEMBER, LEADER, ADMIN, COLEADER]
+    private String warPreference; // 전쟁 선호도 ENUM: [IN, OUT]
+    private Integer donations; // 지원병력 수
+    private Integer donationsReceived; // 지원받은 병력의 수
+    private Integer clanCapitalContributions; // 클랜 캐피탈 기여도
+
+
+
+}

--- a/src/main/java/com/dmk/coctown/player/service/PlayerService.java
+++ b/src/main/java/com/dmk/coctown/player/service/PlayerService.java
@@ -1,0 +1,53 @@
+package com.dmk.coctown.player.service;
+
+import com.dmk.coctown.player.dto.Player;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class PlayerService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${coc.token}")
+    private String token;
+
+    public Player searchPlayer(String playerTag) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.AUTHORIZATION, "Bearer " + token);
+
+        HttpEntity<String> requestEntity = new HttpEntity<>(headers);
+        
+        URI uri = UriComponentsBuilder
+                .fromHttpUrl("https://api.clashofclans.com/v1/players")
+                .path("/{playerTag}")
+                .buildAndExpand("#" + playerTag)
+                .toUri();
+
+        log.debug("uri: {}", uri);
+
+        ResponseEntity<Player> response = restTemplate.exchange(
+                uri,
+                HttpMethod.GET,
+                requestEntity,
+                Player.class);
+
+        return response.getBody();
+
+    }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,2 +1,3 @@
 spring.profiles.active: local
+spring.profiles.include: coc
 spring.datasource.driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <h1>메인</h1>
+</body>
+</html>


### PR DESCRIPTION
## ✅ 이 PR을 통해 해결하려는 문제가 무엇인가요?

- clashofclans api의 player api를 사용해서 특정 플레이어의 정보를 조회하는 기능을 구현함.

## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇인가요?

- `RestTemplate`를 사용해서 clashofclans api와 통신하는 부분이 추가됨.  

## 🔖 핵심 변경 사항 외에 추가적으로 변경된 부분이 있나요?

- clashofclans api 통신을 위한 데이터를 가져오기 위한 application-coc.yml 파일이 추가됨.

This closed #3 